### PR TITLE
Added cyl and hcyl commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
-configurations.all {
+configurations.configureEach {
 	// Check for snapshots more frequently than Gradle's default of 1 day. 0 = every build.
 	resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
 }
@@ -28,6 +28,14 @@ repositories {
 	}
 	maven { url = "https://www.cursemaven.com" }
 	maven { url = "https://masa.dy.fi/maven" }
+
+	// Meteor client repositories
+	maven {
+		url "https://maven.meteordev.org/snapshots"
+	}
+	maven {
+		url "https://maven.meteordev.org/releases"
+	}
 }
 
 dependencies {
@@ -35,10 +43,15 @@ dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	// Fabric API. This is technically optional, but you probably want it anyway.
+	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
     // Meteor client
-	modImplementation files("libs\\baritone-unoptimized-fabric-1.20.2-SNAPSHOT.jar")
-    modImplementation files("libs\\meteor-client-0.5.5.jar")
+//	modImplementation files("libs\\baritone-unoptimized-fabric-1.20.2-SNAPSHOT.jar")
+//  modImplementation files("libs\\meteor-client-0.5.5.jar")
+	// Meteor Client for repositories
+	modImplementation "meteordevelopment:meteor-client:${project.meteor_version}"
+	modImplementation  "baritone:fabric:${project.baritone_version}"
 
 	// Journey Map
 	modCompileOnlyApi  group: 'info.journeymap', name: 'journeymap-api', version: project.journeymap_api_fabric_version, changing: true
@@ -52,6 +65,14 @@ dependencies {
 	modImplementation "curse.maven:litematica-${project.litematica_projectid}:${project.litematica_fileid}"
 	modImplementation "curse.maven:litematica-${project.malilib_projectid}:${project.malilib_fileid}"
 	// modImplementation "fi.dy.masa.malilib:malilib-fabric-${project.minecraft_version}:${project.malilib_version}"
+
+	/**
+	 * For detailed information regarding the Lombok license,
+	 * please refer to the (https://projectlombok.org/LICENSE) in the Lombok project.
+	 */
+	implementation 'org.projectlombok:lombok:1.18.28'
+	annotationProcessor 'org.projectlombok:lombok:1.18.28'
+	testAnnotationProcessor 'org.projectlombok:lombok:1.18.28'
 }
 
 loom {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,10 @@ org.gradle.jvmargs=-Xmx2G
 # Fabric (https://fabricmc.net/versions.html)
 minecraft_version=1.20.2
 yarn_mappings=1.20.2+build.4
-loader_version=0.14.22
+loader_version=0.15.1
+
+# Dependencies
+fabric_version=0.91.2+1.20.2
 
 # Mod Properties
 mod_version=1.0.4
@@ -14,7 +17,8 @@ archives_base_name=meteor-plus
 
 # Meteor (https://maven.meteordev.org/)
 # Not used
-meteor_version=0.5.5-SNAPSHOT
+meteor_version = 0.5.5-SNAPSHOT
+baritone_version = 1.20.2-SNAPSHOT
 
 # Journey Map
 journeymap_api_fabric_version=1.20.2-1.9-fabric-SNAPSHOT
@@ -33,3 +37,9 @@ litematica_projectid=308892
 
 malilib_fileid=4788432
 malilib_projectid=303119
+
+# Use proxy
+systemProp.http.proxyHost=localhost
+systemProp.http.proxyPort=7890
+systemProp.https.proxyHost=localhost
+systemProp.https.proxyPort=7890

--- a/src/main/java/nekiplay/meteorplus/MeteorPlus.java
+++ b/src/main/java/nekiplay/meteorplus/MeteorPlus.java
@@ -15,6 +15,8 @@ import nekiplay.meteorplus.features.modules.*;
 import nekiplay.meteorplus.features.modules.integrations.LitematicaPrinter;
 import nekiplay.meteorplus.features.modules.integrations.MapIntegration;
 import nekiplay.meteorplus.features.modules.timer.TimerPlus;
+import nekiplay.meteorplus.utils.manager.CommandManager;
+import nekiplay.meteorplus.utils.manager.ModuleManager;
 import net.fabricmc.loader.api.FabricLoader;
 import meteordevelopment.meteorclient.addons.MeteorAddon;
 import meteordevelopment.meteorclient.systems.modules.Category;
@@ -39,6 +41,9 @@ public class MeteorPlus extends MeteorAddon {
 	public static final String LOGPREFIX = "[Meteor+]";
 
 	private static MeteorPlus instance;
+
+	private static String COMMAND_PACKAGE = "nekiplay.meteorplus.features.commands";
+	private static String MODULE_PACKAGE = "nekiplay.meteorplus.features.modules";
 
 	public static MeteorPlus getInstance() {
 		return instance;
@@ -120,6 +125,20 @@ public class MeteorPlus extends MeteorAddon {
 		LOG.info(LOGPREFIX + " loaded tabs");
 		//endregion
 		LOG.info(LOGPREFIX + " loaded");
+
+		/**
+		 * CommandManager and ModuleManager will automatically scan all Command subclasses
+		 * under this package and register them with Commands; Assuming they all use @AutoRegistry.
+		 */
+		CommandManager cmdManager = new CommandManager(COMMAND_PACKAGE);
+		cmdManager.registry(Commands::add);
+
+		ModuleManager moduleManager = new ModuleManager(MODULE_PACKAGE);
+		moduleManager.addToIgnoreClass(
+			"nekiplay.meteorplus.features.modules.integrations.journeymap.JourneyMapMeteorPlus"
+		);
+		moduleManager.registry(Modules.get()::add);
+
 	}
 
 	@Override

--- a/src/main/java/nekiplay/meteorplus/features/commands/baritone/CircleCalculation.java
+++ b/src/main/java/nekiplay/meteorplus/features/commands/baritone/CircleCalculation.java
@@ -8,12 +8,18 @@ public class CircleCalculation {
 	public static List<Coordinate> makeCylinder(Coordinate center, int radius) {
 		final List<Coordinate> object = new ArrayList<>();
 		for (int x = 0; x <= (int) Math.ceil(radius + 0.5); ++x) {
-			for (int z = 0; z <= (int) Math.ceil(radius + 0.5); ++z) {
-				double xn = x * (1 / (radius + 0.5));
-				double zn = z * (1 / (radius + 0.5));
-				if (isInsiderCylinder(xn, zn)) {
-					addCylinderCoordinates(object, center, x, z);
-				}
+			object.addAll(calcCylinder(center, x, radius));
+		}
+		return object;
+	}
+
+	private static List<Coordinate> calcCylinder(Coordinate center, int x, int radius) {
+		ArrayList<Coordinate> object = new ArrayList<>();
+		for (int z = 0; z < (int) Math.ceil(radius + 0.5); ++z) {
+			double xn = x * (1 / (radius + 0.5));
+			double zn = z * (1 / (radius + 0.5));
+			if (isInsiderCylinder(xn, zn)) {
+				addCylinderCoordinates(object, center, x, z);
 			}
 		}
 		return object;

--- a/src/main/java/nekiplay/meteorplus/features/commands/baritone/CircleCalculation.java
+++ b/src/main/java/nekiplay/meteorplus/features/commands/baritone/CircleCalculation.java
@@ -11,18 +11,25 @@ public class CircleCalculation {
 			for (int z = 0; z <= (int) Math.ceil(radius + 0.5); ++z) {
 				double xn = x * (1 / (radius + 0.5));
 				double zn = z * (1 / (radius + 0.5));
-				if ((xn * xn + zn * zn) > 1) continue;
-				addToList(
-					object,
-					center.add(x, center.getY(), z),
-					center.add(-x, center.getY(), z),
-					center.add(x, center.getY(), -z),
-					center.add(-x, center.getY(), -z)
-				);
+				if (isInsiderCylinder(xn, zn)) {
+					addCylinderCoordinates(object, center, x, z);
+				}
 			}
 		}
 		return object;
 	}
+
+	private static boolean isInsiderCylinder(double xn, double zn) {
+		return Math.pow(xn, 2) + Math.pow(zn, 2) <= 1;
+	}
+
+	private static void addCylinderCoordinates(List<Coordinate> object, Coordinate center, int x, int z) {
+		addToList(object, center.add(x, center.getY(), z),
+			center.add(-x, center.getY(), z),
+			center.add(x, center.getY(), -z),
+			center.add(-x, center.getY(), -z));
+	}
+
 
 	private static void addToList(List<Coordinate> posList, Coordinate... pos) {
 		for (Coordinate p : pos) {
@@ -76,7 +83,7 @@ public class CircleCalculation {
 
 		objects.add(new PositionBean(
 			new Coordinate(info.getCenterPos().x, info.getCenterPos().y, info.getCenterPos().z - info.getRadius()),
-			new Coordinate(info.getCenterPos().x, info.getCenterPos().y + info.getHeight()-1, info.getCenterPos().z - info.getRadius())
+			new Coordinate(info.getCenterPos().x, info.getCenterPos().y + info.getHeight() - 1, info.getCenterPos().z - info.getRadius())
 		));
 		objects.add(new PositionBean(
 			new Coordinate(info.getCenterPos().x, info.getCenterPos().y, info.getCenterPos().z + info.getRadius()),

--- a/src/main/java/nekiplay/meteorplus/features/commands/baritone/CircleCalculation.java
+++ b/src/main/java/nekiplay/meteorplus/features/commands/baritone/CircleCalculation.java
@@ -46,7 +46,7 @@ public class CircleCalculation {
 	public static List<PositionBean> calcNotHollowPosition(List<Coordinate> pos, CylinderRecord info) {
 		List<PositionBean> objects = new ArrayList<>();
 		for (Coordinate coordinate : calcPosition(pos, info)) {
-			addToNotHollowList(mirror(coordinate, info), objects);
+			addPosition(objects, mirror(coordinate, info));
 		}
 		objects.forEach(o -> {
 			o.getSecond().addY(info.getHeight() - 1);
@@ -56,17 +56,6 @@ public class CircleCalculation {
 			new Coordinate(info.getCenterPos().x, info.getCenterPos().y + info.getHeight() - 1, info.getCenterPos().z + info.getRadius())
 		);
 		return objects;
-	}
-
-	private static void addToNotHollowList(Coordinate[] pos, List<PositionBean> container) {
-		for (int i = 0; i < pos.length; i += 2) {
-			container.add(
-				new PositionBean(
-					pos[i],
-					pos[i + 1]
-				)
-			);
-		}
 	}
 
 	private static Coordinate[] mirror(Coordinate pos, CylinderRecord info) {

--- a/src/main/java/nekiplay/meteorplus/features/commands/baritone/CircleCalculation.java
+++ b/src/main/java/nekiplay/meteorplus/features/commands/baritone/CircleCalculation.java
@@ -1,0 +1,124 @@
+package nekiplay.meteorplus.features.commands.baritone;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CircleCalculation {
+
+	public static List<Coordinate> makeCylinder(Coordinate center, int radius) {
+		final List<Coordinate> object = new ArrayList<>();
+		final int crx = (int) Math.ceil(radius + 0.5);
+		final int crz = (int) Math.ceil(radius + 0.5);
+		for (int x = 0; x <= crx; ++x) {
+			for (int z = 0; z <= crz; ++z) {
+				double xn = x * (1 / (radius + 0.5));
+				double zn = z * (1 / (radius + 0.5));
+				if ((xn * xn + zn * zn) > 1) continue;
+				addToList(
+					object,
+					center.add(x, center.getY(), z),
+					center.add(-x, center.getY(), z),
+					center.add(x, center.getY(), -z),
+					center.add(-x, center.getY(), -z)
+				);
+			}
+		}
+		return object;
+	}
+
+	private static void addToList(List<Coordinate> posList, Coordinate... pos) {
+		for (Coordinate p : pos) {
+			if (!posList.contains(p)) posList.add(p);
+		}
+	}
+
+	public static List<PositionBean> calcNotHollowPosition(List<Coordinate> pos, CylinderRecord info) {
+		List<PositionBean> objects = new ArrayList<>();
+		for (Coordinate coordinate : calcPosition(pos, info)) {
+			addToNotHollowList(mirror(coordinate, info), objects);
+		}
+
+		objects.forEach(o -> {
+			o.getSecond().addY(info.getHeight() - 1);
+		});
+
+		objects.add(new PositionBean(
+			new Coordinate(info.getCenterPos().x, info.getCenterPos().y, info.getCenterPos().z - info.getRadius()),
+			new Coordinate(info.getCenterPos().x, info.getCenterPos().y + info.getHeight() - 1, info.getCenterPos().z + info.getRadius())
+		));
+
+		return objects;
+	}
+
+	private static void addToNotHollowList(Coordinate[] pos, List<PositionBean> container) {
+		for (int i = 0; i < pos.length; i += 2) {
+			container.add(
+				new PositionBean(
+					pos[i],
+					pos[i + 1]
+				)
+			);
+		}
+	}
+
+	private static Coordinate[] mirror(Coordinate pos, CylinderRecord info) {
+		return new Coordinate[]{
+			pos,
+			new Coordinate(pos.x, pos.y, info.getCenterPos().getZ() - (pos.z - info.getCenterPos().getZ())),
+			new Coordinate(info.getCenterPos().getX() - (pos.x - info.getCenterPos().getX()), pos.y, pos.z),
+			new Coordinate(info.getCenterPos().getX() - (pos.x - info.getCenterPos().getX()), pos.y, info.getCenterPos().getZ() - (pos.z - info.getCenterPos().getZ()))
+		};
+	}
+
+	public static List<PositionBean> calcWithHollowPosition(List<Coordinate> pos, CylinderRecord info) {
+		List<PositionBean> objects = new ArrayList<>();
+		for (Coordinate coordinate : calcPosition(pos, info)) {
+			addToHollowList(mirror(coordinate, info), objects, info);
+		}
+
+		objects.add(new PositionBean(
+			new Coordinate(info.getCenterPos().x, info.getCenterPos().y, info.getCenterPos().z - info.getRadius()),
+			new Coordinate(info.getCenterPos().x, info.getCenterPos().y + info.getHeight()-1, info.getCenterPos().z - info.getRadius())
+		));
+		objects.add(new PositionBean(
+			new Coordinate(info.getCenterPos().x, info.getCenterPos().y, info.getCenterPos().z + info.getRadius()),
+			new Coordinate(info.getCenterPos().x, info.getCenterPos().y + info.getHeight() - 1, info.getCenterPos().z + info.getRadius())
+		));
+		return objects;
+	}
+
+	private static void addToHollowList(Coordinate[] pos, List<PositionBean> container, CylinderRecord info) {
+		if (pos[0].getX() - info.getCenterPos().getX() == info.getRadius()) {
+			container.add(
+				new PositionBean(pos[0], pos[1].addY(info.getHeight() - 1))
+			);
+			container.add(
+				new PositionBean(pos[2], pos[3].addY(info.getHeight() - 1))
+			);
+			return;
+		}
+		for (Coordinate p : pos) {
+			container.add(
+				new PositionBean(p, Coordinate.of(p.x, p.y + info.getHeight() - 1, p.z))
+			);
+		}
+	}
+
+	private static List<Coordinate> calcPosition(List<Coordinate> pos, CylinderRecord info) {
+		List<PositionBean> objects = new ArrayList<>();
+		int radius = info.getRadius();
+		int height = info.getHeight();
+		Coordinate center = info.getCenterPos();
+
+		List<Coordinate> temp = new ArrayList<>();
+		for (int i = radius; i > 0; i--) {
+			for (int j = radius; j > 0; j--) {
+				Coordinate p = new Coordinate(center.getX() + i, center.getY(), center.getZ() + j);
+				if (!pos.contains(p)) continue;
+				temp.add(p);
+				break;
+			}
+		}
+		return temp;
+	}
+}

--- a/src/main/java/nekiplay/meteorplus/features/commands/baritone/CircleCalculation.java
+++ b/src/main/java/nekiplay/meteorplus/features/commands/baritone/CircleCalculation.java
@@ -48,16 +48,13 @@ public class CircleCalculation {
 		for (Coordinate coordinate : calcPosition(pos, info)) {
 			addToNotHollowList(mirror(coordinate, info), objects);
 		}
-
 		objects.forEach(o -> {
 			o.getSecond().addY(info.getHeight() - 1);
 		});
-
-		objects.add(new PositionBean(
+		addPosition(objects,
 			new Coordinate(info.getCenterPos().x, info.getCenterPos().y, info.getCenterPos().z - info.getRadius()),
 			new Coordinate(info.getCenterPos().x, info.getCenterPos().y + info.getHeight() - 1, info.getCenterPos().z + info.getRadius())
-		));
-
+		);
 		return objects;
 	}
 
@@ -87,15 +84,20 @@ public class CircleCalculation {
 			addToHollowList(mirror(coordinate, info), objects, info);
 		}
 
-		objects.add(new PositionBean(
+		addPosition(objects,
 			new Coordinate(info.getCenterPos().x, info.getCenterPos().y, info.getCenterPos().z - info.getRadius()),
-			new Coordinate(info.getCenterPos().x, info.getCenterPos().y + info.getHeight() - 1, info.getCenterPos().z - info.getRadius())
-		));
-		objects.add(new PositionBean(
+			new Coordinate(info.getCenterPos().x, info.getCenterPos().y + info.getHeight() - 1, info.getCenterPos().z - info.getRadius()),
 			new Coordinate(info.getCenterPos().x, info.getCenterPos().y, info.getCenterPos().z + info.getRadius()),
 			new Coordinate(info.getCenterPos().x, info.getCenterPos().y + info.getHeight() - 1, info.getCenterPos().z + info.getRadius())
-		));
+		);
 		return objects;
+	}
+
+	private static void addPosition(List<PositionBean> o, Coordinate... pos) {
+		if (pos.length % 2 != 0) return;
+		for (int i = 0; i < pos.length; i += 2) {
+			o.add(new PositionBean(pos[i], pos[i + 1]));
+		}
 	}
 
 	private static void addToHollowList(Coordinate[] pos, List<PositionBean> container, CylinderRecord info) {

--- a/src/main/java/nekiplay/meteorplus/features/commands/baritone/CircleCalculation.java
+++ b/src/main/java/nekiplay/meteorplus/features/commands/baritone/CircleCalculation.java
@@ -116,20 +116,24 @@ public class CircleCalculation {
 	}
 
 	private static List<Coordinate> calcPosition(List<Coordinate> pos, CylinderRecord info) {
-		List<PositionBean> objects = new ArrayList<>();
 		int radius = info.getRadius();
-		int height = info.getHeight();
-		Coordinate center = info.getCenterPos();
-
 		List<Coordinate> temp = new ArrayList<>();
 		for (int i = radius; i > 0; i--) {
-			for (int j = radius; j > 0; j--) {
-				Coordinate p = new Coordinate(center.getX() + i, center.getY(), center.getZ() + j);
-				if (!pos.contains(p)) continue;
-				temp.add(p);
-				break;
-			}
+			temp.addAll(makePosition(pos, info, i));
 		}
 		return temp;
+	}
+
+	private static List<Coordinate> makePosition(List<Coordinate> pos, CylinderRecord info, int i) {
+		Coordinate center = info.getCenterPos();
+		int radius = info.getRadius();
+		List<Coordinate> object = new ArrayList<>();
+		for (int j = radius; j > 0; j--) {
+			Coordinate p = new Coordinate(center.getX() + i, center.getY(), center.getZ() + j);
+			if (!pos.contains(p)) continue;
+			object.add(p);
+			break;
+		}
+		return object;
 	}
 }

--- a/src/main/java/nekiplay/meteorplus/features/commands/baritone/CircleCalculation.java
+++ b/src/main/java/nekiplay/meteorplus/features/commands/baritone/CircleCalculation.java
@@ -7,10 +7,8 @@ public class CircleCalculation {
 
 	public static List<Coordinate> makeCylinder(Coordinate center, int radius) {
 		final List<Coordinate> object = new ArrayList<>();
-		final int crx = (int) Math.ceil(radius + 0.5);
-		final int crz = (int) Math.ceil(radius + 0.5);
-		for (int x = 0; x <= crx; ++x) {
-			for (int z = 0; z <= crz; ++z) {
+		for (int x = 0; x <= (int) Math.ceil(radius + 0.5); ++x) {
+			for (int z = 0; z <= (int) Math.ceil(radius + 0.5); ++z) {
 				double xn = x * (1 / (radius + 0.5));
 				double zn = z * (1 / (radius + 0.5));
 				if ((xn * xn + zn * zn) > 1) continue;

--- a/src/main/java/nekiplay/meteorplus/features/commands/baritone/Coordinate.java
+++ b/src/main/java/nekiplay/meteorplus/features/commands/baritone/Coordinate.java
@@ -11,4 +11,23 @@ public class Coordinate {
 	public Coordinate add(int x, int y, int z) {
 		return new Coordinate(this.x + x, this.y, this.z + z);
 	}
+
+	public static Coordinate of(int x, int y, int z) {
+		return new Coordinate(x, y, z);
+	}
+
+	public Coordinate addX(int x) {
+		this.x += x;
+		return this;
+	}
+
+	public Coordinate addY(int y) {
+		this.y += y;
+		return this;
+	}
+
+	public Coordinate addZ(int z) {
+		this.z += z;
+		return this;
+	}
 }

--- a/src/main/java/nekiplay/meteorplus/features/commands/baritone/Coordinate.java
+++ b/src/main/java/nekiplay/meteorplus/features/commands/baritone/Coordinate.java
@@ -1,0 +1,14 @@
+package nekiplay.meteorplus.features.commands.baritone;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class Coordinate {
+	int x, y, z;
+
+	public Coordinate add(int x, int y, int z) {
+		return new Coordinate(this.x + x, this.y, this.z + z);
+	}
+}

--- a/src/main/java/nekiplay/meteorplus/features/commands/baritone/CylCommand.java
+++ b/src/main/java/nekiplay/meteorplus/features/commands/baritone/CylCommand.java
@@ -1,0 +1,144 @@
+package nekiplay.meteorplus.features.commands.baritone;
+
+import baritone.api.BaritoneAPI;
+import baritone.api.command.manager.ICommandManager;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import lombok.NonNull;
+import meteordevelopment.meteorclient.commands.Command;
+import nekiplay.meteorplus.utils.manager.AutoRegistry;
+import net.minecraft.command.CommandSource;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import static meteordevelopment.meteorclient.MeteorClient.mc;
+
+@AutoRegistry
+public class CylCommand extends Command {
+
+	public static final String RADIUS = "radius";
+	public static final String HEIGHT = "height";
+
+	public static List<Coordinate> makeCylinder(@NonNull Coordinate centerPos, double radiusX, double radiusZ) {
+		radiusX += 0.5;
+		radiusZ += 0.5;
+
+		final List<Coordinate> object = new ArrayList<>();
+
+		final double invRadiusX = 1 / radiusX;
+		final double invRadiusZ = 1 / radiusZ;
+
+		final int ceilRadiusX = (int) Math.ceil(radiusX);
+		final int ceilRadiusZ = (int) Math.ceil(radiusZ);
+
+		// Only select coordinates on the boundary with a step size
+		for (int x = 0; x <= ceilRadiusX; ++x) {
+			for (int z = 0; z <= ceilRadiusZ; ++z) {
+				double xn = x * invRadiusX;
+				double zn = z * invRadiusZ;
+
+				double distanceSq = (xn * xn + zn * zn);
+				if (distanceSq <= 1) {
+					CylCommand.add(centerPos.add(x, centerPos.getY(), z), object);
+					CylCommand.add(centerPos.add(-x, centerPos.getY(), z), object);
+					CylCommand.add(centerPos.add(x, centerPos.getY(), -z), object);
+					CylCommand.add(centerPos.add(-x, centerPos.getY(), -z), object);
+				}
+			}
+		}
+		return object;
+	}
+
+	public static void add(@NonNull Coordinate pos, @NonNull List<Coordinate> coordinates) {
+		if (coordinates.contains(pos)) {
+			return;
+		}
+		coordinates.add(pos);
+	}
+
+	public static void execSel(@NonNull List<Coordinate> pos, Coordinate center, int radius, int height, boolean hollow) {
+		for (int i = radius; i > 0; i--) {
+			for (int j = radius; j > 0; j--) {
+				int x = center.getX() + i;
+				int z = center.getZ() + j;
+				int y = center.getY();
+				if (pos.contains(new Coordinate(x, y, z))) {
+					Coordinate p1 = new Coordinate(x, y, z);
+					Coordinate p2 = new Coordinate(x, y, center.getZ() - (z - center.getZ()));
+					Coordinate l1 = new Coordinate(center.getX() - (x - center.getX()), center.getY(), z);
+					Coordinate l2 = new Coordinate(center.getX() - (x - center.getX()), center.getY(), center.getZ() - (z - center.getZ()));
+					if (height > 1 && !hollow) {
+						p2.setY(center.getY() + height - 1);
+						l2.setY(center.getY() + height - 1);
+					}
+					if (hollow) {
+						if (p1.getX() - center.getX() == radius || p1.getX() - center.getX() == -radius) {
+							selPos(p1, new Coordinate(p2.getX(), p2.getY() + height - 1, p2.getZ()));
+							selPos(l1, new Coordinate(l2.getX(), l2.getY() + height - 1, l2.getZ()));
+						} else {
+							selPos(p1, new Coordinate(p1.getX(), p1.getY() + height - 1, p1.getZ()));
+							selPos(p2, new Coordinate(p2.getX(), p2.getY() + height - 1, p2.getZ()));
+							selPos(l1, new Coordinate(l1.getX(), l1.getY() + height - 1, l1.getZ()));
+							selPos(l2, new Coordinate(l2.getX(), l2.getY() + height - 1, l2.getZ()));
+						}
+					} else {
+						selPos(p1, p2);
+						selPos(l1, l2);
+					}
+					break;
+				}
+			}
+		}
+		Coordinate p1 = new Coordinate(center.getX(), center.getY(), center.getZ() - radius);
+		Coordinate p2 = new Coordinate(center.getX(), center.getY(), center.getZ() + radius);
+		if (height > 1 && !hollow) {
+			p2.setY(center.getY() + height - 1);
+		}
+		if (hollow) {
+			selPos(p1, new Coordinate(p1.getX(), p1.getY() + height - 1, p1.getZ()));
+			selPos(p2, new Coordinate(p2.getX(), p2.getY() + height - 1, p2.getZ()));
+		} else {
+			selPos(p1, p2);
+		}
+	}
+
+	public static void selPos(@NonNull Coordinate pos1, @NonNull Coordinate pos2) {
+		ICommandManager commandManager = BaritoneAPI.getProvider().getPrimaryBaritone().getCommandManager();
+		String sel1 = String.format("sel 1 %d %d %d", pos1.getX(), pos1.getY(), pos1.getZ());
+		String sel2 = String.format("sel 2 %d %d %d", pos2.getX(), pos2.getY(), pos2.getZ());
+		commandManager.execute(sel1);
+		commandManager.execute(sel2);
+	}
+
+	@Override
+	public void build(LiteralArgumentBuilder<CommandSource> builder) {
+		builder.then(
+			argument(RADIUS, IntegerArgumentType.integer(1)).then(
+				argument(HEIGHT, IntegerArgumentType.integer(1))
+					.executes(this::execute)
+			)
+		);
+	}
+
+	private int execute(CommandContext<CommandSource> context) {
+		BlockPos blockPos = mc.player.getBlockPos();
+		int radius = context.getArgument(RADIUS, Integer.class);
+		int height = context.getArgument(HEIGHT, Integer.class);
+		Coordinate centerBlock = new Coordinate(blockPos.getX(), blockPos.getY(), blockPos.getZ());
+		List<Coordinate> coordinates = makeCylinder(
+			centerBlock,
+			radius,
+			radius
+		);
+		execSel(coordinates, centerBlock, radius, height, false);
+		return SINGLE_SUCCESS;
+	}
+
+	public CylCommand() {
+		super("cyl", "Mark a solid cylinder using command '#sel'");
+	}
+}

--- a/src/main/java/nekiplay/meteorplus/features/commands/baritone/CylCommand.java
+++ b/src/main/java/nekiplay/meteorplus/features/commands/baritone/CylCommand.java
@@ -11,107 +11,31 @@ import nekiplay.meteorplus.utils.manager.AutoRegistry;
 import net.minecraft.command.CommandSource;
 import net.minecraft.util.math.BlockPos;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 @AutoRegistry
 public class CylCommand extends Command {
-
 	public static final String RADIUS = "radius";
 	public static final String HEIGHT = "height";
 
-	public static List<Coordinate> makeCylinder(@NonNull Coordinate centerPos, double radiusX, double radiusZ) {
-		radiusX += 0.5;
-		radiusZ += 0.5;
-
-		final List<Coordinate> object = new ArrayList<>();
-
-		final double invRadiusX = 1 / radiusX;
-		final double invRadiusZ = 1 / radiusZ;
-
-		final int ceilRadiusX = (int) Math.ceil(radiusX);
-		final int ceilRadiusZ = (int) Math.ceil(radiusZ);
-
-		// Only select coordinates on the boundary with a step size
-		for (int x = 0; x <= ceilRadiusX; ++x) {
-			for (int z = 0; z <= ceilRadiusZ; ++z) {
-				double xn = x * invRadiusX;
-				double zn = z * invRadiusZ;
-
-				double distanceSq = (xn * xn + zn * zn);
-				if (distanceSq <= 1) {
-					CylCommand.add(centerPos.add(x, centerPos.getY(), z), object);
-					CylCommand.add(centerPos.add(-x, centerPos.getY(), z), object);
-					CylCommand.add(centerPos.add(x, centerPos.getY(), -z), object);
-					CylCommand.add(centerPos.add(-x, centerPos.getY(), -z), object);
-				}
-			}
-		}
-		return object;
-	}
-
-	public static void add(@NonNull Coordinate pos, @NonNull List<Coordinate> coordinates) {
-		if (coordinates.contains(pos)) {
-			return;
-		}
-		coordinates.add(pos);
-	}
-
-	public static void execSel(@NonNull List<Coordinate> pos, Coordinate center, int radius, int height, boolean hollow) {
-		for (int i = radius; i > 0; i--) {
-			for (int j = radius; j > 0; j--) {
-				int x = center.getX() + i;
-				int z = center.getZ() + j;
-				int y = center.getY();
-				if (pos.contains(new Coordinate(x, y, z))) {
-					Coordinate p1 = new Coordinate(x, y, z);
-					Coordinate p2 = new Coordinate(x, y, center.getZ() - (z - center.getZ()));
-					Coordinate l1 = new Coordinate(center.getX() - (x - center.getX()), center.getY(), z);
-					Coordinate l2 = new Coordinate(center.getX() - (x - center.getX()), center.getY(), center.getZ() - (z - center.getZ()));
-					if (height > 1 && !hollow) {
-						p2.setY(center.getY() + height - 1);
-						l2.setY(center.getY() + height - 1);
-					}
-					if (hollow) {
-						if (p1.getX() - center.getX() == radius || p1.getX() - center.getX() == -radius) {
-							selPos(p1, new Coordinate(p2.getX(), p2.getY() + height - 1, p2.getZ()));
-							selPos(l1, new Coordinate(l2.getX(), l2.getY() + height - 1, l2.getZ()));
-						} else {
-							selPos(p1, new Coordinate(p1.getX(), p1.getY() + height - 1, p1.getZ()));
-							selPos(p2, new Coordinate(p2.getX(), p2.getY() + height - 1, p2.getZ()));
-							selPos(l1, new Coordinate(l1.getX(), l1.getY() + height - 1, l1.getZ()));
-							selPos(l2, new Coordinate(l2.getX(), l2.getY() + height - 1, l2.getZ()));
-						}
-					} else {
-						selPos(p1, p2);
-						selPos(l1, l2);
-					}
-					break;
-				}
-			}
-		}
-		Coordinate p1 = new Coordinate(center.getX(), center.getY(), center.getZ() - radius);
-		Coordinate p2 = new Coordinate(center.getX(), center.getY(), center.getZ() + radius);
-		if (height > 1 && !hollow) {
-			p2.setY(center.getY() + height - 1);
-		}
-		if (hollow) {
-			selPos(p1, new Coordinate(p1.getX(), p1.getY() + height - 1, p1.getZ()));
-			selPos(p2, new Coordinate(p2.getX(), p2.getY() + height - 1, p2.getZ()));
-		} else {
-			selPos(p1, p2);
-		}
-	}
-
-	public static void selPos(@NonNull Coordinate pos1, @NonNull Coordinate pos2) {
+	public static void execSelCmd(@NonNull Coordinate pos1, @NonNull Coordinate pos2) {
 		ICommandManager commandManager = BaritoneAPI.getProvider().getPrimaryBaritone().getCommandManager();
 		String sel1 = String.format("sel 1 %d %d %d", pos1.getX(), pos1.getY(), pos1.getZ());
 		String sel2 = String.format("sel 2 %d %d %d", pos2.getX(), pos2.getY(), pos2.getZ());
 		commandManager.execute(sel1);
 		commandManager.execute(sel2);
+	}
+
+	public static void execSelCmd(PositionBean position) {
+		execSelCmd(position.getFirst(), position.getSecond());
+	}
+
+	public static void execAll(List<PositionBean> positions) {
+		positions.forEach(CylCommand::execSelCmd);
 	}
 
 	@Override
@@ -125,20 +49,19 @@ public class CylCommand extends Command {
 	}
 
 	private int execute(CommandContext<CommandSource> context) {
-		BlockPos blockPos = mc.player.getBlockPos();
+		BlockPos blockPos = Objects.requireNonNull(mc.player).getBlockPos();
 		int radius = context.getArgument(RADIUS, Integer.class);
-		int height = context.getArgument(HEIGHT, Integer.class);
 		Coordinate centerBlock = new Coordinate(blockPos.getX(), blockPos.getY(), blockPos.getZ());
-		List<Coordinate> coordinates = makeCylinder(
-			centerBlock,
-			radius,
-			radius
+		List<PositionBean> positionBeans = CircleCalculation.calcNotHollowPosition(
+			CircleCalculation.makeCylinder(centerBlock, radius),
+			new CylinderRecord(centerBlock, radius, context.getArgument(HEIGHT, Integer.class))
 		);
-		execSel(coordinates, centerBlock, radius, height, false);
+		CylCommand.execAll(positionBeans);
 		return SINGLE_SUCCESS;
 	}
 
 	public CylCommand() {
 		super("cyl", "Mark a solid cylinder using command '#sel'");
 	}
+
 }

--- a/src/main/java/nekiplay/meteorplus/features/commands/baritone/CylinderRecord.java
+++ b/src/main/java/nekiplay/meteorplus/features/commands/baritone/CylinderRecord.java
@@ -1,0 +1,13 @@
+package nekiplay.meteorplus.features.commands.baritone;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NonNull;
+
+@AllArgsConstructor
+@Data
+public class CylinderRecord {
+	@NonNull private Coordinate centerPos;
+	private int radius;
+	private int height;
+}

--- a/src/main/java/nekiplay/meteorplus/features/commands/baritone/HCylCommand.java
+++ b/src/main/java/nekiplay/meteorplus/features/commands/baritone/HCylCommand.java
@@ -9,6 +9,7 @@ import net.minecraft.command.CommandSource;
 import net.minecraft.util.math.BlockPos;
 
 import java.util.List;
+import java.util.Objects;
 
 import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
 import static meteordevelopment.meteorclient.MeteorClient.mc;
@@ -32,13 +33,15 @@ public class HCylCommand extends Command {
 	}
 
 	private int execute(CommandContext<CommandSource> context) {
-		BlockPos blockPos = mc.player.getBlockPos();
+		BlockPos blockPos = Objects.requireNonNull(mc.player).getBlockPos();
 		Coordinate centerPos = new Coordinate(blockPos.getX(), blockPos.getY(), blockPos.getZ());
 		int radius = context.getArgument(CylCommand.RADIUS, Integer.class);
 		int height = context.getArgument(CylCommand.HEIGHT, Integer.class);
-
-		List<Coordinate> coordinates = CylCommand.makeCylinder(centerPos, radius, radius);
-		CylCommand.execSel(coordinates, centerPos, radius, height, true);
+		List<PositionBean> positionBeans = CircleCalculation.calcWithHollowPosition(
+			CircleCalculation.makeCylinder(centerPos, radius),
+			new CylinderRecord(centerPos, radius, height)
+		);
+		CylCommand.execAll(positionBeans);
 		return SINGLE_SUCCESS;
 	}
 }

--- a/src/main/java/nekiplay/meteorplus/features/commands/baritone/HCylCommand.java
+++ b/src/main/java/nekiplay/meteorplus/features/commands/baritone/HCylCommand.java
@@ -1,0 +1,45 @@
+package nekiplay.meteorplus.features.commands.baritone;
+
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import meteordevelopment.meteorclient.commands.Command;
+import nekiplay.meteorplus.utils.manager.AutoRegistry;
+import net.minecraft.command.CommandSource;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.List;
+
+import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import static meteordevelopment.meteorclient.MeteorClient.mc;
+
+@AutoRegistry
+public class HCylCommand extends Command {
+
+
+	public HCylCommand() {
+		super("hcyl", "Mark a hollow cylinder using command '#sel'");
+	}
+
+	@Override
+	public void build(LiteralArgumentBuilder<CommandSource> builder) {
+		builder.then(
+			argument(CylCommand.RADIUS, IntegerArgumentType.integer(1)).then(
+				argument(CylCommand.HEIGHT, IntegerArgumentType.integer(1))
+					.executes(this::execute)
+			)
+		);
+	}
+
+	private int execute(CommandContext<CommandSource> context) {
+		BlockPos blockPos = mc.player.getBlockPos();
+		Coordinate centerPos = new Coordinate(blockPos.getX(), blockPos.getY(), blockPos.getZ());
+		int radius = context.getArgument(CylCommand.RADIUS, Integer.class);
+		int height = context.getArgument(CylCommand.HEIGHT, Integer.class);
+
+		List<Coordinate> coordinates = CylCommand.makeCylinder(centerPos, radius, radius);
+		CylCommand.execSel(coordinates, centerPos, radius, height, true);
+		return SINGLE_SUCCESS;
+	}
+}
+

--- a/src/main/java/nekiplay/meteorplus/features/commands/baritone/PositionBean.java
+++ b/src/main/java/nekiplay/meteorplus/features/commands/baritone/PositionBean.java
@@ -1,0 +1,12 @@
+package nekiplay.meteorplus.features.commands.baritone;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NonNull;
+
+@AllArgsConstructor
+@Data
+public class PositionBean {
+	@NonNull private Coordinate first;
+	@NonNull private Coordinate second;
+}

--- a/src/main/java/nekiplay/meteorplus/utils/manager/AutoRegistry.java
+++ b/src/main/java/nekiplay/meteorplus/utils/manager/AutoRegistry.java
@@ -1,0 +1,10 @@
+package nekiplay.meteorplus.utils.manager;
+
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface AutoRegistry {
+}

--- a/src/main/java/nekiplay/meteorplus/utils/manager/CommandManager.java
+++ b/src/main/java/nekiplay/meteorplus/utils/manager/CommandManager.java
@@ -4,11 +4,9 @@ import lombok.NonNull;
 import lombok.SneakyThrows;
 import meteordevelopment.meteorclient.commands.Command;
 
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 public class CommandManager {
 	private final List<Class<? extends Command>> _command;
@@ -31,24 +29,14 @@ public class CommandManager {
 
 	@SneakyThrows
 	public void registry(Consumer<Command> consumer) {
-		if (!loaded) this.build();
+		if (!loaded) this.buildCommand();
 		for (Class<? extends Command> cmd : _command) {
 			consumer.accept(cmd.getDeclaredConstructor().newInstance());
 		}
 	}
 
-
-	private void build() {
-		PackageScanner scanner = new PackageScanner();
-		List<Class<?>> classes = scanner.getClasses(this.commandPackage);
-		List<Class<? extends Command>> cs = classes.stream()
-			.filter(Command.class::isAssignableFrom)
-			.filter(clazz -> clazz.isAnnotationPresent(AutoRegistry.class))
-			.filter(clazz -> !Modifier.isAbstract(clazz.getModifiers()))
-			.map(clazz -> (Class<? extends Command>) clazz.asSubclass(Command.class))
-			.collect(Collectors.toList());
-		this._command.addAll(cs);
-		loaded = true;
+	private void buildCommand(){
+		this.loaded = MeteorManager.build(scanner, _command, commandPackage, Command.class);
 	}
 
 	public CommandManager(@NonNull String pkg) {

--- a/src/main/java/nekiplay/meteorplus/utils/manager/CommandManager.java
+++ b/src/main/java/nekiplay/meteorplus/utils/manager/CommandManager.java
@@ -1,0 +1,59 @@
+package nekiplay.meteorplus.utils.manager;
+
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import meteordevelopment.meteorclient.commands.Command;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class CommandManager {
+	private final List<Class<? extends Command>> _command;
+	private final PackageScanner scanner;
+	String commandPackage;
+	boolean loaded;
+
+	public void addToIgnoreClass(String... className) {
+		for (String s : className) {
+			scanner.addToIgnoreClass(s);
+		}
+	}
+
+	public void addToIgnorePackage(String... packageName) {
+		for (String s : packageName) {
+			scanner.addToIgnorePackage(s);
+		}
+	}
+
+
+	@SneakyThrows
+	public void registry(Consumer<Command> consumer) {
+		if (!loaded) this.build();
+		for (Class<? extends Command> cmd : _command) {
+			consumer.accept(cmd.getDeclaredConstructor().newInstance());
+		}
+	}
+
+
+	private void build() {
+		PackageScanner scanner = new PackageScanner();
+		List<Class<?>> classes = scanner.getClasses(this.commandPackage);
+		List<Class<? extends Command>> cs = classes.stream()
+			.filter(Command.class::isAssignableFrom)
+			.filter(clazz -> clazz.isAnnotationPresent(AutoRegistry.class))
+			.filter(clazz -> !Modifier.isAbstract(clazz.getModifiers()))
+			.map(clazz -> (Class<? extends Command>) clazz.asSubclass(Command.class))
+			.collect(Collectors.toList());
+		this._command.addAll(cs);
+		loaded = true;
+	}
+
+	public CommandManager(@NonNull String pkg) {
+		this.commandPackage = pkg;
+		_command = new ArrayList<>();
+		scanner = new PackageScanner();
+	}
+}

--- a/src/main/java/nekiplay/meteorplus/utils/manager/MeteorManager.java
+++ b/src/main/java/nekiplay/meteorplus/utils/manager/MeteorManager.java
@@ -1,0 +1,20 @@
+package nekiplay.meteorplus.utils.manager;
+
+import java.lang.reflect.Modifier;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public interface MeteorManager {
+
+	static <T> boolean build(PackageScanner scanner, List<Class<? extends T>> container, String pkg, Class<T> type) {
+		List<Class<?>> classes = scanner.getClasses(pkg);
+		List<Class<? extends T>> ms = classes.stream()
+			.filter(type::isAssignableFrom)
+			.filter(clazz -> clazz.isAnnotationPresent(AutoRegistry.class))
+			.filter(clazz -> !Modifier.isAbstract(clazz.getModifiers()))
+			.map(clazz -> (Class<? extends T>) clazz.asSubclass(type))
+			.collect(Collectors.toList());
+		container.addAll(ms);
+		return true;
+	}
+}

--- a/src/main/java/nekiplay/meteorplus/utils/manager/ModuleManager.java
+++ b/src/main/java/nekiplay/meteorplus/utils/manager/ModuleManager.java
@@ -1,0 +1,58 @@
+package nekiplay.meteorplus.utils.manager;
+
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import meteordevelopment.meteorclient.systems.modules.Module;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class ModuleManager {
+	private final List<Class<? extends Module>> _module;
+	private final PackageScanner scanner;
+	String modulePackage;
+	boolean loaded;
+
+	public void addToIgnoreClass(String... className) {
+		for (String s : className) {
+			scanner.addToIgnoreClass(s);
+		}
+	}
+
+	public void addToIgnorePackage(String... packageName) {
+		for (String s : packageName) {
+			scanner.addToIgnorePackage(s);
+		}
+	}
+
+
+	@SneakyThrows
+	public void registry(Consumer<Module> consumer) {
+		if (!loaded) this.build();
+		for (Class<? extends Module> module : this._module) {
+			consumer.accept(module.getDeclaredConstructor().newInstance());
+		}
+	}
+
+	private void build() {
+		List<Class<?>> classes = scanner.getClasses(this.modulePackage);
+		List<Class<? extends Module>> ms = classes.stream()
+			.filter(Module.class::isAssignableFrom)
+			.filter(clazz -> clazz.isAnnotationPresent(AutoRegistry.class))
+			.filter(clazz -> !Modifier.isAbstract(clazz.getModifiers()))
+			.map(clazz -> (Class<? extends Module>) clazz.asSubclass(Module.class))
+			.collect(Collectors.toList());
+		this._module.addAll(ms);
+		loaded = true;
+	}
+
+
+	public ModuleManager(@NonNull String modulePackage) {
+		this.modulePackage = modulePackage;
+		_module = new ArrayList<>();
+		scanner = new PackageScanner();
+	}
+}

--- a/src/main/java/nekiplay/meteorplus/utils/manager/ModuleManager.java
+++ b/src/main/java/nekiplay/meteorplus/utils/manager/ModuleManager.java
@@ -4,11 +4,9 @@ import lombok.NonNull;
 import lombok.SneakyThrows;
 import meteordevelopment.meteorclient.systems.modules.Module;
 
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 public class ModuleManager {
 	private final List<Class<? extends Module>> _module;
@@ -28,25 +26,16 @@ public class ModuleManager {
 		}
 	}
 
-
 	@SneakyThrows
 	public void registry(Consumer<Module> consumer) {
-		if (!loaded) this.build();
+		if (!loaded) this.buildModule();
 		for (Class<? extends Module> module : this._module) {
 			consumer.accept(module.getDeclaredConstructor().newInstance());
 		}
 	}
 
-	private void build() {
-		List<Class<?>> classes = scanner.getClasses(this.modulePackage);
-		List<Class<? extends Module>> ms = classes.stream()
-			.filter(Module.class::isAssignableFrom)
-			.filter(clazz -> clazz.isAnnotationPresent(AutoRegistry.class))
-			.filter(clazz -> !Modifier.isAbstract(clazz.getModifiers()))
-			.map(clazz -> (Class<? extends Module>) clazz.asSubclass(Module.class))
-			.collect(Collectors.toList());
-		this._module.addAll(ms);
-		loaded = true;
+	private void buildModule() {
+		this.loaded = MeteorManager.build(scanner, this._module, modulePackage, Module.class);
 	}
 
 

--- a/src/main/java/nekiplay/meteorplus/utils/manager/PackageScanner.java
+++ b/src/main/java/nekiplay/meteorplus/utils/manager/PackageScanner.java
@@ -1,0 +1,113 @@
+package nekiplay.meteorplus.utils.manager;
+
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+
+import java.io.File;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+
+/**
+ * This is a simple package scanner used to scan all classes under a
+ * specified package
+ */
+@NoArgsConstructor
+public class PackageScanner {
+
+	private final List<String> ignoreClass = new ArrayList<>();
+	private final List<String> ignorePackage = new ArrayList<>();
+
+	public void addToIgnoreClass(String className) {
+		ignoreClass.add(className);
+	}
+
+	public void addToIgnorePackage(String packageName) {
+		ignorePackage.add(packageName);
+	}
+
+	private boolean isIgnored(String className) {
+		if (ignoreClass.contains(className)) {
+			return true;
+		}
+		for (String ignoredPackage : ignorePackage) {
+			if (className.startsWith(ignoredPackage)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+
+	/**
+	 * Scans all classes under the specified package.
+	 *
+	 * @param pkg The name of the package to be scanned.
+	 * @return A list containing the names of the scanned classes.
+	 */
+	@SneakyThrows
+	public List<Class<?>> getClasses(@NonNull String pkg) {
+		List<Class<?>> classes = new ArrayList<>();
+		String path = pkg.replace('.', '/');
+		ClassLoader loader = Thread.currentThread().getContextClassLoader();
+		Enumeration<URL> resources = loader.getResources(path);
+
+		while (resources.hasMoreElements()) {
+			URL url = resources.nextElement();
+			if (url.getProtocol().equals("file")) {
+				File file = new File(url.getFile());
+				classes.addAll(findClasses(file, pkg));
+			} else if (url.getProtocol().equals("jar")) {
+				JarURLConnection jarURLConnection = (JarURLConnection) url.openConnection();
+				JarFile jarFile = jarURLConnection.getJarFile();
+				classes.addAll(findClassesInJar(jarFile, path));
+			}
+		}
+		return classes;
+	}
+
+	@SneakyThrows
+	private Collection<Class<?>> findClassesInJar(JarFile jarFile, String path) {
+		List<Class<?>> classes = new ArrayList<>();
+		Enumeration<JarEntry> entries = jarFile.entries();
+
+		while (entries.hasMoreElements()) {
+			JarEntry jarEntry = entries.nextElement();
+			String name = jarEntry.getName();
+
+			if (name.startsWith(path) && name.endsWith(".class")) {
+				String className = name.substring(0, name.length() - 6).replace('/', '.');
+				if (!isIgnored(className)) classes.add(Class.forName(className));
+			}
+		}
+		return classes;
+	}
+
+	@SneakyThrows
+	private Collection<Class<?>> findClasses(File file, String pkg) {
+		List<Class<?>> classes = new ArrayList<>();
+		if (!file.exists()) return classes;
+
+		File[] files = file.listFiles();
+		if (null != files) {
+			for (File iFile : files) {
+				if (iFile.isDirectory()) {
+					assert !iFile.getName().contains(".");
+					classes.addAll(findClasses(iFile, pkg + "." + iFile.getName()));
+				} else if (iFile.getName().endsWith(".class")) {
+					String className = pkg + "." + iFile.getName().substring(0, iFile.getName().length() - 6);
+					if (!isIgnored(className)) classes.add(Class.forName(className));
+				}
+			}
+		}
+		return classes;
+	}
+
+}

--- a/src/main/java/nekiplay/meteorplus/utils/manager/PackageScanner.java
+++ b/src/main/java/nekiplay/meteorplus/utils/manager/PackageScanner.java
@@ -8,7 +8,6 @@ import java.io.File;
 import java.net.JarURLConnection;
 import java.net.URL;
 import java.util.*;
-import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 


### PR DESCRIPTION
Added `cyl` and `hcyl` commands, which compensates for the drawback of the `#sel` command in 'Baritone' that cannot select circles. Unfortunately, these two commands are still based on the `# sel` command.

![2023-12-11_08 24 02](https://github.com/Nekiplay/MeteorPlus/assets/81049953/83970808-1850-448f-91b7-d2162c6f9ec4)
![2023-12-11_08 24 14](https://github.com/Nekiplay/MeteorPlus/assets/81049953/94ba5ed5-d73c-48f6-b49c-d26c2b2090bb)
![2023-12-11_08 24 24](https://github.com/Nekiplay/MeteorPlus/assets/81049953/bf14ad78-1a57-4060-a4fb-d109d0a95f24)
